### PR TITLE
Redesigning onOpen() and onClose() callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ Scaffold(
 | children | The widgets below this widget in the tree |  |
 | foregroundColor | The default foreground color for icons and text within the button |  |
 | backgroundColor | The button's background color |  |
-| onOpen | Execute when the menu opens |  |
-| onClose | Execute when the menu closes |  |
+| beforeOpen | Will be called before opening the menu |  |
+| afterOpen | Will be called after opening the menu |  |
+| beforeClose | Will be called before the menu closes |  |
+| afterClose | Will be called after the menu closes |  |
 | overlayStyle | Provides the style for overlay. No overlay when null. |  |
 
 

--- a/lib/flutter_expandable_fab.dart
+++ b/lib/flutter_expandable_fab.dart
@@ -86,8 +86,10 @@ class ExpandableFab extends StatefulWidget {
     this.child = const Icon(Icons.menu),
     this.childrenOffset = const Offset(4, 4),
     required this.children,
-    this.onOpen,
-    this.onClose,
+    this.beforeOpen,
+    this.afterOpen,
+    this.beforeClose,
+    this.afterClose,
     this.overlayStyle,
   }) : super(key: key);
 
@@ -124,11 +126,17 @@ class ExpandableFab extends StatefulWidget {
   /// The button's background color.
   final Color? backgroundColor;
 
-  /// Execute when the menu opens.
-  final VoidCallback? onOpen;
+  /// Will be called before opening the menu.
+  final VoidCallback? beforeOpen;
 
-  /// Execute when the menu closes.
-  final VoidCallback? onClose;
+  /// Will be called after opening the menu.
+  final VoidCallback? afterOpen;
+
+  /// Will be called before the menu closes.
+  final VoidCallback? beforeClose;
+
+  /// Will be called after the menu closes.
+  final VoidCallback? afterClose;
 
   /// Provides the style for overlay. No overlay when null.
   final ExpandableFabOverlayStyle? overlayStyle;
@@ -151,11 +159,15 @@ class ExpandableFabState extends State<ExpandableFab>
     setState(() {
       _open = !_open;
       if (_open) {
-        widget.onOpen?.call();
-        _controller.forward();
+        widget.beforeOpen?.call();
+        _controller.forward().then((value) {
+          widget.afterOpen?.call();
+        });
       } else {
-        widget.onClose?.call();
-        _controller.reverse();
+        widget.beforeClose?.call();
+        _controller.reverse().then((value) {
+          widget.afterClose?.call();
+        });
       }
     });
   }


### PR DESCRIPTION
Hello!

I would like to suggest changes to the repository that would allow users to catch not just menu open and close events, but their more detailed counterparts: `beforeOpen()`, `afterOpen()`, `beforeClose()`, `afterClose()`.

I personally need this to start the animation that will run after the menu is fully opened.
But in fact, such more detailed callbacks may be needed in many cases.

I would be very grateful if you consider these changes and merge them into your repository!
If you do not agree, I will have to publish my own package, which will be the same as yours, except for these callbacks, which looks undesirable, in my opinion.
Your package is cool!

Consider please.