### PR TITLE
Added new event callbacks (afterOpen() / afterClose())

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ Scaffold(
 | children | The widgets below this widget in the tree |  |
 | foregroundColor | The default foreground color for icons and text within the button |  |
 | backgroundColor | The button's background color |  |
-| onOpen | Execute when the menu opens |  |
-| onClose | Execute when the menu closes |  |
+| onOpen | Will be called before opening the menu |  |
+| afterOpen | Will be called after opening the menu |  |
+| onClose | Will be called before the menu closes |  |
+| afterClose | Will be called after the menu closes |  |
 | overlayStyle | Provides the style for overlay. No overlay when null. |  |
 
 

--- a/README_jp.md
+++ b/README_jp.md
@@ -89,8 +89,10 @@ Scaffold(
 | children | 子アイテム |  |
 | foregroundColor | 子ウィジェットのフォアグラウンドカラー |  |
 | backgroundColor | ボタンの背景色 |  |
-| onOpen | メニューオープンイベントハンドラ |  |
-| onClose | メニュークローズイベントハンドラ |  |
+| onOpen | メニューを開く前に呼び出されます |  |
+| afterOpen | メニューを開いた後に呼び出されます |  |
+| onClose | メニューが閉じる前に呼び出されます |  |
+| afterClose | メニューが閉じた後に呼び出されます |  |
 | overlayStyle | オーバーレイのスタイル、nullで非表示 |  |
 
 

--- a/lib/flutter_expandable_fab.dart
+++ b/lib/flutter_expandable_fab.dart
@@ -87,7 +87,9 @@ class ExpandableFab extends StatefulWidget {
     this.childrenOffset = const Offset(4, 4),
     required this.children,
     this.onOpen,
+    this.afterOpen,
     this.onClose,
+    this.afterClose,
     this.overlayStyle,
   }) : super(key: key);
 
@@ -124,11 +126,17 @@ class ExpandableFab extends StatefulWidget {
   /// The button's background color.
   final Color? backgroundColor;
 
-  /// Execute when the menu opens.
+  /// Will be called before opening the menu.
   final VoidCallback? onOpen;
 
-  /// Execute when the menu closes.
+  /// Will be called after opening the menu.
+  final VoidCallback? afterOpen;
+
+  /// Will be called before the menu closes.
   final VoidCallback? onClose;
+
+  /// Will be called after the menu closes.
+  final VoidCallback? afterClose;
 
   /// Provides the style for overlay. No overlay when null.
   final ExpandableFabOverlayStyle? overlayStyle;
@@ -152,10 +160,14 @@ class ExpandableFabState extends State<ExpandableFab>
       _open = !_open;
       if (_open) {
         widget.onOpen?.call();
-        _controller.forward();
+        _controller.forward().then((value) {
+          widget.afterOpen?.call();
+        });
       } else {
         widget.onClose?.call();
-        _controller.reverse();
+        _controller.reverse().then((value) {
+          widget.afterClose?.call();
+        });
       }
     });
   }


### PR DESCRIPTION
Hello!

To continue and replace another pull request: https://github.com/zuvola/flutter_expandable_fab/pull/5

I would like to suggest changes to the repository that would allow users to catch not just menu open and close events, but also afterOpen() and afterClose().

I need this to start the animation that will run after the menu is fully opened.
But in fact, such more detailed callbacks may be needed in many cases.

I would be very grateful if you consider these changes and merge them into your repository!