### PR TITLE
Allow changing the shape of the FAB

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -69,6 +69,8 @@ class FirstPage extends StatelessWidget {
         //   foregroundColor: Colors.deepOrangeAccent,
         //   backgroundColor: Colors.lightGreen,
         // ),
+        // expandedFabShape: const CircleBorder(),
+        // collapsedFabShape: const CircleBorder(),
         overlayStyle: ExpandableFabOverlayStyle(
           // color: Colors.black.withOpacity(0.5),
           blur: 5,
@@ -87,11 +89,13 @@ class FirstPage extends StatelessWidget {
         },
         children: [
           FloatingActionButton.small(
+            // shape: const CircleBorder(),
             heroTag: null,
             child: const Icon(Icons.edit),
             onPressed: () {},
           ),
           FloatingActionButton.small(
+            // shape: const CircleBorder(),
             heroTag: null,
             child: const Icon(Icons.search),
             onPressed: () {
@@ -100,6 +104,7 @@ class FirstPage extends StatelessWidget {
             },
           ),
           FloatingActionButton.small(
+            // shape: const CircleBorder(),
             heroTag: null,
             child: const Icon(Icons.share),
             onPressed: () {

--- a/lib/flutter_expandable_fab.dart
+++ b/lib/flutter_expandable_fab.dart
@@ -85,6 +85,8 @@ class ExpandableFab extends StatefulWidget {
     this.type = ExpandableFabType.fan,
     this.collapsedFabSize = ExpandableFabSize.regular,
     this.expandedFabSize = ExpandableFabSize.small,
+    this.collapsedFabShape,
+    this.expandedFabShape,
     this.closeButtonStyle = const ExpandableFabCloseButtonStyle(),
     this.foregroundColor,
     this.backgroundColor,
@@ -120,6 +122,12 @@ class ExpandableFab extends StatefulWidget {
 
   /// The size of the expanded FAB.
   final ExpandableFabSize expandedFabSize;
+
+  /// The shape of the expanded FAB's [Material].
+  final ShapeBorder? expandedFabShape;
+
+  /// The shape of the collapsed FAB's [Material].
+  final ShapeBorder? collapsedFabShape;
 
   /// Style of the close button.
   final ExpandableFabCloseButtonStyle closeButtonStyle;
@@ -302,6 +310,7 @@ class ExpandableFabState extends State<ExpandableFab>
           heroTag: widget.closeButtonHeroTag,
           foregroundColor: style.foregroundColor,
           backgroundColor: style.backgroundColor,
+          shape: widget.expandedFabShape,
           onPressed: toggle,
           child: style.child,
         );
@@ -310,6 +319,7 @@ class ExpandableFabState extends State<ExpandableFab>
           heroTag: widget.closeButtonHeroTag,
           foregroundColor: style.foregroundColor,
           backgroundColor: style.backgroundColor,
+          shape: widget.expandedFabShape,
           onPressed: toggle,
           child: style.child,
         );
@@ -379,6 +389,7 @@ class ExpandableFabState extends State<ExpandableFab>
                   heroTag: widget.openButtonHeroTag,
                   foregroundColor: widget.foregroundColor,
                   backgroundColor: widget.backgroundColor,
+                  shape: widget.collapsedFabShape,
                   onPressed: toggle,
                   child: AnimatedRotation(
                     duration: duration,
@@ -390,6 +401,7 @@ class ExpandableFabState extends State<ExpandableFab>
                   heroTag: widget.openButtonHeroTag,
                   foregroundColor: widget.foregroundColor,
                   backgroundColor: widget.backgroundColor,
+                  shape: widget.collapsedFabShape,
                   onPressed: toggle,
                   child: AnimatedRotation(
                     duration: duration,


### PR DESCRIPTION
Added the ability to change the `ShapeBorder` of the FAB for the collapsed and expanded states with the `collapsedFabShape` and `expandedFabShape` attributes.

This allows the button to have a circular shape for example (just like the one used in Material Design v2).