### PR TITLE
fix overlap with snackbar

### DIFF
--- a/lib/flutter_expandable_fab.dart
+++ b/lib/flutter_expandable_fab.dart
@@ -67,7 +67,7 @@ class _ExpandableFabLocation extends StandardFabLocation {
   @override
   double getOffsetY(
       ScaffoldPrelayoutGeometry scaffoldGeometry, double adjustment) {
-    return 0;
+    return -scaffoldGeometry.snackBarSize.height;
   }
 }
 


### PR DESCRIPTION
Currently the fab doesn't react to the appearance of the standard snackbar showing up.

This change takes care of this issue and adjusts the reaction of the fab to the appearance and disappearance of the snackbar to look the same as with the standard fab.