### PR TITLE
Update expandable_fab.dart

### DIFF
--- a/lib/src/expandable_fab.dart
+++ b/lib/src/expandable_fab.dart
@@ -183,35 +183,32 @@ class ExpandableFabState extends State<ExpandableFab>
   bool _open = false;
 
   /// Returns whether the menu is open
-  bool get isOpen => _open;
+  bool get isOpen => _controller.value > 0.5;
 
   /// Display or hide the menu.
-  void toggle() {
-    setState(() {
-      _open = !_open;
-      if (_open) {
-        widget.onOpen?.call();
-        _controller.forward().then((value) {
-          widget.afterOpen?.call();
-        });
-      } else {
-        widget.onClose?.call();
-        _controller.reverse().then((value) {
-          widget.afterClose?.call();
-        });
-      }
-    });
+ void toggle() {
+    if (_controller.isAnimating) return;
+    if (_controller.value == 0.0) {
+      widget.onOpen?.call();
+      _controller.forward().then((_) {
+        widget.afterOpen?.call();
+      });
+    } else if (_controller.value == 1.0) {
+      widget.onClose?.call();
+      _controller.reverse().then((_) {
+        widget.afterClose?.call();
+      });
+    }
   }
 
   @override
   void initState() {
     super.initState();
-    _open = widget.initialOpen;
     _controller = AnimationController(
-      value: _open ? 1.0 : 0.0,
+      value: widget.initialOpen ? 1.0 : 0.0,
       duration: widget.duration,
       vsync: this,
-    );
+    )..addListener(() => setState(() {}));
     _expandAnimation = CurvedAnimation(
       curve: Curves.fastOutSlowIn,
       reverseCurve: Curves.easeOutQuad,
@@ -228,7 +225,6 @@ class ExpandableFabState extends State<ExpandableFab>
   @override
   void didUpdateWidget(covariant ExpandableFab oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _open = widget.initialOpen;
     _controller.duration = widget.duration;
     _openButtonBuilder = widget.openButtonBuilder ?? _defaultOpenButtonBuilder;
     _closeButtonBuilder =
@@ -248,7 +244,6 @@ class ExpandableFabState extends State<ExpandableFab>
     Widget? cache;
     final ScaffoldState? scaffold =
         context.findAncestorStateOfType<ScaffoldState>();
-
     return ValueListenableBuilder<ScaffoldPrelayoutGeometry?>(
       valueListenable: location.scaffoldGeometry,
       builder: ((context, geometry, child) {
@@ -273,13 +268,14 @@ class ExpandableFabState extends State<ExpandableFab>
         }
         final bottomContentHeight =
             geometry.scaffoldSize.height - geometry.contentBottom;
-        final y = kFloatingActionButtonMargin +
+        final y =
+            kFloatingActionButtonMargin +
             math.max(geometry.minViewPadding.bottom, bottomContentHeight);
         if (offset != Offset(x, y)) {
           offset = Offset(x, y);
           cache = _buildButtons(offset!);
         }
-        return _open ? FocusScope(child: cache!) : cache!;
+        return _controller.value > 0.0 ? FocusScope(child: cache!) : cache!;
       }),
     );
   }
@@ -292,8 +288,8 @@ class ExpandableFabState extends State<ExpandableFab>
           (widget.pos == ExpandableFabPos.left
               ? widget.margin.left
               : widget.pos == ExpandableFabPos.center
-                  ? 0
-                  : widget.margin.right),
+              ? 0
+              : widget.margin.right),
       offset.dy + widget.margin.bottom,
     );
     final Alignment alignment;
@@ -315,31 +311,23 @@ class ExpandableFabState extends State<ExpandableFab>
           Container(),
           if (overlayColor != null)
             IgnorePointer(
-              ignoring: !_open,
+              ignoring: !isOpen,
               child: FadeTransition(
                 opacity: _expandAnimation,
-                child: Container(
-                  color: overlayColor,
-                ),
+                child: Container(color: overlayColor),
               ),
             ),
           if (blur != null)
             IgnorePointer(
-              ignoring: !_open,
-              child: TweenAnimationBuilder<double>(
-                tween: Tween<double>(
-                  begin: _open ? 0.0 : blur,
-                  end: _open ? blur : 0.0,
-                ),
-                duration: widget.duration,
-                curve: Curves.easeInOut,
-                builder: (_, value, child) {
-                  if (value < 0.001) {
-                    return child!;
-                  }
+              ignoring: !isOpen,
+              child: AnimatedBuilder(
+                animation: _expandAnimation,
+                builder: (_, child) {
+                  final sigma = _expandAnimation.value * blur;
+                  if (sigma < 0.001) return child!;
                   return ClipRect(
                     child: BackdropFilter(
-                      filter: ImageFilter.blur(sigmaX: value, sigmaY: value),
+                      filter: ImageFilter.blur(sigmaX: sigma, sigmaY: sigma),
                       child: child,
                     ),
                   );
@@ -356,7 +344,10 @@ class ExpandableFabState extends State<ExpandableFab>
                 FadeTransition(
                   opacity: _expandAnimation,
                   child: _closeButtonBuilder.builder(
-                      context, toggle, _expandAnimation),
+                    context,
+                    toggle,
+                    _expandAnimation,
+                  ),
                 ),
                 _buildTapToOpenFab(),
               ],
@@ -377,14 +368,17 @@ class ExpandableFabState extends State<ExpandableFab>
     var totalOffset = offset;
     switch (widget.pos) {
       case ExpandableFabPos.left:
-        totalOffset += Offset(-widget.childrenOffset.dx - buttonOffset,
-            widget.childrenOffset.dy + buttonOffset);
+        totalOffset += Offset(
+          -widget.childrenOffset.dx - buttonOffset,
+          widget.childrenOffset.dy + buttonOffset,
+        );
         break;
       case ExpandableFabPos.center:
         final screenSize = MediaQuery.of(context).size;
         totalOffset = Offset(
-            screenSize.width / 2 - _closeButtonBuilder.size / 2,
-            offset.dy + buttonOffset);
+          screenSize.width / 2 - _closeButtonBuilder.size / 2,
+          offset.dy + buttonOffset,
+        );
         break;
       default:
         totalOffset +=
@@ -433,9 +427,8 @@ class ExpandableFabState extends State<ExpandableFab>
   Widget _buildTapToOpenFab() {
     final transformValues = _closeButtonBuilder.size / _openButtonBuilder.size;
     final reverse = ReverseAnimation(_expandAnimation);
-
     return IgnorePointer(
-      ignoring: _open,
+      ignoring: isOpen,
       child: ScaleTransition(
         scale: Tween(begin: transformValues, end: 1.0).animate(reverse),
         child: FadeTransition(
@@ -450,10 +443,11 @@ class ExpandableFabState extends State<ExpandableFab>
 class _ExpandableFabLocation extends StandardFabLocation {
   final ValueNotifier<ScaffoldPrelayoutGeometry?> scaffoldGeometry =
       ValueNotifier(null);
-
   @override
   double getOffsetX(
-      ScaffoldPrelayoutGeometry scaffoldGeometry, double adjustment) {
+    ScaffoldPrelayoutGeometry scaffoldGeometry,
+    double adjustment,
+  ) {
     Future.microtask(() {
       this.scaffoldGeometry.value = scaffoldGeometry;
     });
@@ -462,7 +456,9 @@ class _ExpandableFabLocation extends StandardFabLocation {
 
   @override
   double getOffsetY(
-      ScaffoldPrelayoutGeometry scaffoldGeometry, double adjustment) {
+    ScaffoldPrelayoutGeometry scaffoldGeometry,
+    double adjustment,
+  ) {
     return -scaffoldGeometry.snackBarSize.height;
   }
 }
@@ -478,7 +474,6 @@ class _ExpandingActionButton extends StatelessWidget {
     required this.offset,
     required this.animation,
   });
-
   final double directionInDegrees;
   final double maxDistance;
   final Animation<double> progress;
@@ -486,7 +481,6 @@ class _ExpandingActionButton extends StatelessWidget {
   final ExpandableFabPos fabPos;
   final Widget child;
   final ExpandableFabAnimation animation;
-
   @override
   Widget build(BuildContext context) {
     return AnimatedBuilder(
@@ -501,20 +495,15 @@ class _ExpandingActionButton extends StatelessWidget {
           left: fabPos == ExpandableFabPos.left ? -offset.dx + pos.dx : null,
           bottom: offset.dy + pos.dy,
           child: Transform.rotate(
-            angle: animation == ExpandableFabAnimation.rotate
-                ? (1.0 - progress.value) * math.pi / 2
-                : 0,
-            child: IgnorePointer(
-              ignoring: progress.value != 1,
-              child: child,
-            ),
+            angle:
+                animation == ExpandableFabAnimation.rotate
+                    ? (1.0 - progress.value) * math.pi / 2
+                    : 0,
+            child: IgnorePointer(ignoring: progress.value != 1, child: child),
           ),
         );
       },
-      child: FadeTransition(
-        opacity: progress,
-        child: child,
-      ),
+      child: FadeTransition(opacity: progress, child: child),
     );
   }
 }

--- a/lib/src/expandable_fab.dart
+++ b/lib/src/expandable_fab.dart
@@ -222,7 +222,7 @@ class ExpandableFabState extends State<ExpandableFab>
       _closeButtonBuilder = widget.closeButtonBuilder!;
     }
 
-    Future.delayed(const Duration(milliseconds: 300), () {
+    Future.delayed(const Duration(milliseconds: 400), () {
       if (mounted) {
         setState(() {
           _delayDone = true;


### PR DESCRIPTION
Fix expandable FAB closing bug and eliminate unnecessary blur flicker

This PR addresses three issues in the custom expandable FAB widget:

It fixes a bug where rapid tapping during the closing animation prevented the FAB from closing properly.

It resolves an on-mount blur flicker that occurred during the close transition, ensuring smoother and more consistent animations.

It fixes a bug where the fab flickers from the center to the specified location.